### PR TITLE
Refactor [3]: Make quad example compileable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # inspirv-rust
 
 An experimental compiler from [Rust] to [SPIR-V], using the `rustc` compiler and [MIR].
-The code is based upon [miri] and [mir2wasm].
+The code is based upon [rustc_trans::mir], legacy version was based on [miri] and [mir2wasm].
 
 > rustc 1.15.0-nightly (daf8c1dfc 2016-12-05)
 
@@ -21,9 +21,7 @@ cargo run -- rust-examples\quad.rs --extern std=libstd.rlib --extern core=libcor
 
 ## Resources
 
-* [miri](https://github.com/solson/miri) the MIR interpreter. mir2wasm is derived
-  from it but shares no actual code. It probably should share code though, and
-  there's lots to learn from miri.
+* [miri](https://github.com/solson/miri) the MIR interpreter.
 * [rustc_trans::mir](https://github.com/rust-lang/rust/tree/master/src/librustc_trans/mir).
 * [mir2wasm](https://github.com/brson/mir2wasm)
 

--- a/rust-examples/quad.rs
+++ b/rust-examples/quad.rs
@@ -25,22 +25,24 @@ struct Locals {
     dimensions: Float2,
 }
 
+/*
 #[inspirv(entry_point = "vertex")]
 fn vertex(vertex: Attributes<QuadVertex>) -> QuadVarying {
     QuadVarying {
-        pos: vertex.pos,
-        color: vertex.color,
+        pos: Float4::new(0.0, 0.0, 0.0, 1.0), //vertex.pos,
+        color: Float4::new(0.0, 0.0, 0.0, 1.0), //vertex.color,
     }
 }
+*/
 
 #[inspirv(entry_point = "fragment")]
 fn fragment(varying: Attributes<QuadVarying>, fragment: Attributes<QuadFragment>, local: Cbuffer<Locals>) -> QuadOut {
-    let w = local.dimensions.x;
-    let h = local.dimensions.x;
+    // let w = local.dimensions.x;
+    // let h = local.dimensions.x;
     QuadOut {
         color: Float4::new(
-            fragment.coord.x / w,
-            fragment.coord.y / h,
+            0.0, //fragment.coord.x / w,
+            0.0, //fragment.coord.y / h,
             0.0, 1.0),
     }
 }

--- a/rust-examples/quad.rs
+++ b/rust-examples/quad.rs
@@ -1,7 +1,6 @@
 #![feature(custom_attribute, attr_literals)]
 #![allow(unused_attributes)]
 
-/*
 struct QuadVertex {
     #[inspirv(location = 0)] pos: Float4,
     #[inspirv(location = 1)] color: Float4,
@@ -43,24 +42,5 @@ fn fragment(varying: Attributes<QuadVarying>, fragment: Attributes<QuadFragment>
             fragment.coord.x / w,
             fragment.coord.y / h,
             0.0, 1.0),
-    }
-}
-*/
-
-extern crate test_lib;
-
-struct QuadVertex {
-    #[inspirv(location = 1)] color: Float4,
-}
-
-struct QuadVarying {
-}
-
-#[inspirv(entry_point = "vertex")]
-fn vertex() -> QuadVarying {
-    use test_lib::Foo;
-    let x = 0u32;
-    x.foo();
-    QuadVarying {
     }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -14,14 +14,14 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
         let mut bcx = self.bcx(bb);
         let data = &CellRef::clone(&self.mir)[bb];
 
-        println!("trans_block({:?}={:?})", bb, data);
+        println!("trans_block({:?}={:#?})", bb, data);
 
         for statement in &data.statements {
             bcx = self.trans_statement(bcx, statement);
         }
 
         let terminator = data.terminator();
-        println!("trans_block: terminator: {:?}", terminator);
+        println!("trans_block: terminator: {:#?}", terminator);
 
         match terminator.kind {
             mir::TerminatorKind::Return => {
@@ -47,7 +47,13 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
 
             mir::TerminatorKind::Call { ref func, ref args, ref destination, .. } => {
                 let callee = self.trans_operand(&bcx, func);
-                unimplemented!()
+
+                // TODO:
+                bcx.with_block(|block| {
+                    block.spv_block.borrow_mut().branch_instr = Some(
+                        BranchInstruction::Unreachable(OpUnreachable));
+                });
+                // unimplemented!()
             }
 
             mir::TerminatorKind::Drop { target, .. } |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,6 +325,8 @@ pub fn trans_function<'blk, 'tcx: 'blk>(fcx: &'blk FunctionContext<'blk, 'tcx>) 
     let mir = fcx.mir();
     let tcx = fcx.ccx.tcx();
 
+    println!("trans_function: {:?}", mir);
+
     // Allocate a `Block` for every basic block
     let block_bcxs: IndexVec<mir::BasicBlock, Block<'blk,'tcx>> =
         mir.basic_blocks().indices().map(|_| {
@@ -432,33 +434,36 @@ pub fn trans_function<'blk, 'tcx: 'blk>(fcx: &'blk FunctionContext<'blk, 'tcx>) 
                                     builder.name_id_member(ty_id, member as u32, &*field.name.as_str());
                                 }
 
-                                let fields = if let Type::Struct(fields) = ty { fields } else { bug!("cbuffer not a struct!") };
-                                let mut offset = 0;
-                                for (member, field) in fields.iter().enumerate() {
-                                    let unalignment = offset % field.alignment();
-                                    if unalignment != 0 {
-                                        offset += field.alignment() - unalignment;
+                                {
+                                    let fields = if let &Type::Struct(ref fields) = &ty { fields } else { bug!("cbuffer not a struct!") };
+                                    let mut offset = 0;
+                                    for (member, field) in fields.iter().enumerate() {
+                                        let unalignment = offset % field.alignment();
+                                        if unalignment != 0 {
+                                            offset += field.alignment() - unalignment;
+                                        }
+
+                                        builder.add_decoration_member(ty_id, member as u32, Decoration::DecorationOffset(LiteralInteger(offset as u32)));
+                                        offset += field.size_of();
+
+                                        // Matrix types require ColMajor/RowMajor decorations and MatrixStride [SPIR-V 2.16.2]
+                                        if let Type::Matrix { ref base, rows, .. } = *field {
+                                            let stride = Type::Vector { base: base.clone(), components: rows }.size_of();
+                                            builder.add_decoration_member(ty_id, member as u32, Decoration::DecorationMatrixStride(LiteralInteger(stride as u32)));
+                                            builder.add_decoration_member(ty_id, member as u32, Decoration::DecorationColMajor);
+                                        }
                                     }
 
-                                    builder.add_decoration_member(ty_id, member as u32, Decoration::DecorationOffset(LiteralInteger(offset as u32)));
-                                    offset += field.size_of();
-
-                                    // Matrix types require ColMajor/RowMajor decorations and MatrixStride [SPIR-V 2.16.2]
-                                    if let Type::Matrix { ref base, rows, .. } = *field {
-                                        let stride = Type::Vector { base: base.clone(), components: rows }.size_of();
-                                        builder.add_decoration_member(ty_id, member as u32, Decoration::DecorationMatrixStride(LiteralInteger(stride as u32)));
-                                        builder.add_decoration_member(ty_id, member as u32, Decoration::DecorationColMajor);
+                                    let attrs = attributes::attributes(fcx.ccx, struct_ty_did);
+                                    for attr in attrs {
+                                        if let Attribute::Descriptor { set, binding } = attr {
+                                            builder.add_decoration(id, Decoration::DecorationDescriptorSet(LiteralInteger(set as u32)));
+                                            builder.add_decoration(id, Decoration::DecorationBinding(LiteralInteger(binding as u32)));
+                                        }
                                     }
                                 }
 
-                                let attrs = attributes::attributes(fcx.ccx, struct_ty_did);
-                                for attr in attrs {
-                                    if let Attribute::Descriptor { set, binding } = attr {
-                                        builder.add_decoration(id, Decoration::DecorationDescriptorSet(LiteralInteger(set as u32)));
-                                        builder.add_decoration(id, Decoration::DecorationBinding(LiteralInteger(binding as u32)));
-                                    }
-                                }
-
+                                return Some(LocalRef::from(id, SpvType::NoRef(ty)));
                             }
                         }
                         bug!("Const buffer argument type requires to be struct type")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ use syntax::ast::{self, NodeId};
 
 use inspirv::types::{Id, LiteralInteger};
 use inspirv::core::enumeration::*;
-use inspirv_builder::function::{Function, FuncId};
+use inspirv_builder::function::{Function, FuncId, LocalVar};
 use inspirv_builder::module::{ModuleBuilder, Type};
 
 use self::attributes::Attribute;
@@ -495,7 +495,14 @@ pub fn trans_function<'blk, 'tcx: 'blk>(fcx: &'blk FunctionContext<'blk, 'tcx>) 
                 // just skip it..
                 None
             } else {
-                // TODO 
+                // TODO: we need to add references to the final module?
+                let mut fn_def = fcx.spv_fn_decl.borrow_mut();
+                let spv_local = LocalVar {
+                    id: spv_id,
+                    ty: spv_ty.ty().clone(),
+                };
+                fn_def.variables.push(spv_local);
+
                 Some(LocalRef::from(spv_id, spv_ty))
             }
         }).collect::<IndexVec<mir::Local, _>>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ pub fn trans_function<'blk, 'tcx: 'blk>(fcx: &'blk FunctionContext<'blk, 'tcx>) 
     let mir = fcx.mir();
     let tcx = fcx.ccx.tcx();
 
-    println!("trans_function: {:?}", mir);
+    println!("trans_function: {:#?}", mir);
 
     // Allocate a `Block` for every basic block
     let block_bcxs: IndexVec<mir::BasicBlock, Block<'blk,'tcx>> =

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -30,7 +30,7 @@ pub struct ValueRef{
 }
 
 impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
-    fn revolve_lvalue(&mut self,
+    fn resolve_lvalue(&mut self,
                       bcx: &BlockAndBuilder<'bcx, 'tcx>,
                       lvalue: &mir::Lvalue<'tcx>)
                       -> LvalueInner<'tcx> {
@@ -94,7 +94,7 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                         -> LvalueRef<'tcx> {
         println!("trans_lvalue(lvalue={:?})", lvalue);
 
-        let inner = self.revolve_lvalue(bcx, lvalue);
+        let inner = self.resolve_lvalue(bcx, lvalue);
 
         // Lift inner lvalue to an simplier type if possible
         match inner {

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -80,7 +80,10 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                 let const_ty = self.monomorphized_lvalue_ty(lvalue);
                 bug!("unsupported static lvalue {:?}", const_ty)
             }
-            mir::Lvalue::Projection(ref proj) => {
+            mir::Lvalue::Projection(ref projection) => {
+                let tr_base = self.trans_lvalue(bcx, &projection.base);
+                
+                println!("{:?}", (projection, tr_base));
                 unimplemented!()
             }
         };

--- a/src/operand.rs
+++ b/src/operand.rs
@@ -6,7 +6,7 @@ use {BlockAndBuilder, MirContext};
 use lvalue::{LvalueRef, ValueRef};
 
 pub enum OperandValue {
-
+  Immediate(ValueRef),
 }
 
 pub struct OperandRef<'tcx> {
@@ -31,19 +31,11 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
             }
 
             mir::Operand::Constant(ref constant) => {
-                let val = self.trans_constant(bcx, constant);
-
-                /*
-                let operand = val.to_operand(bcx.ccx());
-                if let OperandValue::Ref(ptr) = operand.val {
-                    // If this is a OperandValue::Ref to an immediate constant, load it.
-                    self.trans_load(bcx, ptr, operand.ty)
-                } else {
-                    operand
-                }
-                */
-
-                unimplemented!()
+                let const_val = self.trans_constant(bcx, constant);
+                Some(OperandRef {
+                  val: OperandValue::Immediate(const_val.spv_val),
+                  ty: const_val.ty,
+                })
             }
         }
     }
@@ -82,5 +74,9 @@ impl<'bcx, 'tcx> MirContext<'bcx, 'tcx> {
                          dest: LvalueRef,
                          operand: OperandRef<'tcx>)
     {
+        println!("store_operand: operand={:?}", operand);
+        bcx.with_block(|bcx| {
+
+        });
     }
 }


### PR DESCRIPTION
Bunch of smaller changes and fixes to make the quad example build again (NOT translating everything correctly).